### PR TITLE
Override default mjml validation rules & add new query validation par…

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,11 +56,12 @@ May return:
 To use the API params, you can pass them as query parameters
 `localhost:3001/?comments=false&minfiy=true`.
 
-| Param      | Type       | Default    |
-|------------|------------|------------|
+| Param      | Type       | Default    | Possible values |
+|------------|------------|------------|------------
 | comments    | Boolean | false |
 | minify    | Boolean | false |
 | beautify    | Boolean | false |
+| validation    | String | strict | skip, soft, strict
 
 ## License
 

--- a/test/mjml.test.js
+++ b/test/mjml.test.js
@@ -32,6 +32,40 @@ describe('Convert MJML to HTML', () => {
     })
   })
 
+  it('should not get an error if invalid mjml with a different validation', (done) => {
+    request.post(`${ENDPOINT}?validation=skip`, {
+      body: `<mjml>
+        <mj-body>
+          <mj-wrapper>
+            <mj-wrapper>
+              <mj-section>
+                <mj-column>
+                  <mj-text>
+                    Hello world!
+                  </mj-text>
+                </mj-column>
+                <mj-column>
+                  <mj-text>
+                    Something else.
+                  </mj-text>
+                </mj-column>
+              </mj-section>
+            </mj-wrapper>
+          </mj-wrapper>
+        </mj-body>
+      </mjml>`,
+      headers: {
+        'Content-Type': 'text/plain'
+      }
+    }, (err, response) => {
+      expect(response.statusCode).toEqual(200)
+      expect(response.headers['content-type']).toContain('text/html')
+      expect(response.body).toBeDefined()
+      expect(response.body).toContain('Hello world!')
+      done()
+    })
+  })
+
   it('should get an error if no content provided', (done) => {
     request.post(ENDPOINT, {
       body: '',


### PR DESCRIPTION
This PR adds a new query parameter `validation` to specify the validation level you need. By default it's `strict` but can take the `soft` and `skip` value.

Plus, by default we want to allow the `mj-wrapper` element be nested with another `mj-wrapper` element. To do this, we override the default validation for the `mj-wrapper` component. The reason behind this change is related to our specific use-case.